### PR TITLE
Added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# Ignore compiled files
+*.class
+*.o
+*.pyc
+*.dll
+*.exe
+
+# Ignore system-generated files
+.DS_Store
+Thumbs.db
+
+# Ignore log files
+*.log
+
+# Ignore package files
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+
+# Ignore IDE-specific files and directories
+.idea/
+.vscode/
+
+# Ignore build directories
+/build/
+/out/
+
+# Ignore dependency directories
+/node_modules/
+/bower_components/
+
+# Ignore configuration files with sensitive information
+config.ini
+config.secret
+
+# Ignore generated documentation
+/docs/
+
+# Ignore user-specific files
+*.bak
+*.tmp
+
+# Ignore specific files or directories
+path/to/file.txt
+path/to/directory/
+


### PR DESCRIPTION
## Issue
- Missing .gitignore file
- node_modules was not put in .gitignore which takes too much time clone the repo

## Solution
I have added the .gitignore file and added the file names that must be ignored while pushing the code.

## Additional Information
I am a GSSoC'23 contributor. So kindly add the required tags and also please merge this pull request